### PR TITLE
Change the default size of read pipe to 2MB from 8KB

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
@@ -50,7 +50,7 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
   // Size of buffer to allocate for incoming data.
   // TODO(b/135137108): Figure out what an appropriate default is, and how this impacts
   // performance.
-  private static final int DEFAULT_BUFFER_SIZE = 8192;
+  private static final int DEFAULT_BUFFER_SIZE = 2 * 1024 * 1024;
 
   // GCS gRPC stub.
   private final StorageStub stub;


### PR DESCRIPTION
8KB is too small to suffer performance degradation caused by too many ping pong between the two threads.